### PR TITLE
NODE-2500: (Bug Fix) Mock server still has BSON as property

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,6 @@
 'use strict';
-const Long = require('bson').Long;
+const BSON = require('bson');
+const { Long } = BSON;
 const snappy = require('snappy');
 const zlib = require('zlib');
 const opcodes = require('./utils').opcodes;
@@ -12,7 +13,6 @@ const Request = function(server, connection, response) {
   this.server = server;
   this.connection = connection;
   this.response = response;
-  this.bson = server.bson;
 };
 
 Request.prototype.receive = function() {
@@ -39,7 +39,6 @@ Request.prototype.reply = function(documents, options) {
   let response;
   if (options.compression) {
     response = new CompressedResponse(
-      this.bson,
       {
         cursorId: cursorId,
         responseFlags: responseFlags,
@@ -56,7 +55,7 @@ Request.prototype.reply = function(documents, options) {
       }
     );
   } else {
-    response = new Response(this.bson, documents, {
+    response = new Response(documents, {
       // Header field
       responseTo: this.response.requestId,
       requestId: this.response.requestId + 1,
@@ -96,8 +95,7 @@ Object.defineProperty(Request.prototype, 'document', {
   }
 });
 
-const Response = function(bson, documents, options) {
-  this.bson = bson;
+const Response = function(documents, options) {
   // Header
   this.requestId = options.requestId;
   this.responseTo = options.responseTo;
@@ -117,9 +115,7 @@ const Response = function(bson, documents, options) {
  * @ignore
  * Preparing a compressed response of the OP_COMPRESSED type
  */
-const CompressedResponse = function(bson, uncompressedResponse, options) {
-  this.bson = bson;
-
+const CompressedResponse = function(uncompressedResponse, options) {
   // Header
   this.requestId = options.requestId;
   this.responseTo = options.responseTo;
@@ -139,12 +135,11 @@ const CompressedResponse = function(bson, uncompressedResponse, options) {
 };
 
 Response.prototype.toBin = function() {
-  let self = this;
   let buffers = [];
 
   // Serialize all the docs
   let docs = this.documents.map(function(x) {
-    return self.bson.serialize(x);
+    return BSON.serialize(x);
   });
 
   // Document total size
@@ -194,12 +189,11 @@ Response.prototype.toBin = function() {
 };
 
 CompressedResponse.prototype.toBin = function() {
-  let self = this;
   let buffers = [];
 
   // Serialize all the docs
   let docs = this.uncompressedResponse.documents.map(function(x) {
-    return self.bson.serialize(x);
+    return BSON.serialize(x);
   });
 
   // Document total size

--- a/lib/wire_response.js
+++ b/lib/wire_response.js
@@ -1,6 +1,6 @@
 'use strict';
-
-var Long = require('bson').Long;
+const BSON = require('bson');
+const { Long } = BSON;
 
 // Response flags
 var CURSOR_NOT_FOUND = 0;
@@ -8,7 +8,7 @@ var QUERY_FAILURE = 2;
 var SHARD_CONFIG_STALE = 4;
 var AWAIT_CAPABLE = 8;
 
-var Response = function(bson, data, opts) {
+var Response = function(data, opts) {
   opts = opts || { promoteLongs: true };
   this.parsed = false;
 
@@ -18,7 +18,6 @@ var Response = function(bson, data, opts) {
   this.index = 0;
   this.raw = data;
   this.data = data;
-  this.bson = bson;
   this.opts = opts;
 
   // Read the message length
@@ -131,7 +130,7 @@ Response.prototype.parse = function(options) {
     var _options = { promoteLongs: this.opts.promoteLongs, fieldsAsRaw: fieldsAsRaw };
 
     // Deserialize but keep the array of documents in non-parsed form
-    var doc = this.bson.deserialize(document, _options);
+    var doc = BSON.deserialize(document, _options);
 
     // Get the documents
     this.documents = doc.cursor[documentsReturnedIn];


### PR DESCRIPTION
https://jira.mongodb.org/browse/NODE-2500

I made the changes to use the BSON dependency rather than the bson property. I tested by running the drivers tests against these changes.